### PR TITLE
chore: update go-ipfs dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "debug": "^4.3.3",
         "dotenv": "^16.0.1",
         "format-number": "^3.0.0",
-        "go-ipfs": "^0.12.2",
+        "go-ipfs": "^0.18.0",
         "it-batch": "^2.0.0",
         "it-ndjson": "^0.1.1",
         "it-pipe": "^2.0.5",
@@ -3094,9 +3094,9 @@
       }
     },
     "node_modules/go-ipfs": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/go-ipfs/-/go-ipfs-0.12.2.tgz",
-      "integrity": "sha512-4eA4xFRDM1JfC3W+IkAk2VUauVWKp3zHghiXCs+8SizhNrfajTwzhLduFNnQtjLYicXlhfX1Hjm8uk011ypV6Q==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/go-ipfs/-/go-ipfs-0.18.0.tgz",
+      "integrity": "sha512-CFKHjN7nco2EUxQSdM7AQ3VzLASxwmP4RBDx8TeLqEgn5K2fjIYN7IHkna104UNpsVNhtzVBy0OObBczJWrLUA==",
       "hasInstallScript": true,
       "dependencies": {
         "cachedir": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "debug": "^4.3.3",
     "dotenv": "^16.0.1",
     "format-number": "^3.0.0",
-    "go-ipfs": "^0.12.2",
+    "go-ipfs": "^0.18.0",
     "it-batch": "^2.0.0",
     "it-ndjson": "^0.1.1",
     "it-pipe": "^2.0.5",


### PR DESCRIPTION
This prompted me for a repo migration the first time I ran so you might need to `rm -rf ~/.ipfs` before starting if the repo is persisted.