### PR TITLE
chore: ipfs config update and fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ RUN mkdir -p /home/circleci/app
 WORKDIR /home/circleci/app
 COPY --chown=circleci:circleci package*.json *.js ./
 RUN npm install
-CMD [ "npm", "start" ]
+CMD [ "npm", "start" "--silent"]

--- a/ipfs-client.js
+++ b/ipfs-client.js
@@ -82,11 +82,6 @@ async function withTimeout (signalReceiver, timeout = TIMEOUT) {
   try {
     const res = await signalReceiver(controller.signal)
     return res
-  } catch (err) {
-    if (controller.signal.aborted && err.name === 'AbortError') {
-      err.code = 'ERR_TIMEOUT'
-    }
-    throw err
   } finally {
     clearTimeout(tid)
   }
@@ -108,11 +103,6 @@ async function * withChunkTimeout (signalReceiver, timeout = TIMEOUT) {
       tid = setTimeout(onTimeout, timeout)
       yield chunk
     }
-  } catch (err) {
-    if (controller.signal.aborted && err.name === 'AbortError') {
-      err.code = 'ERR_TIMEOUT'
-    }
-    throw err
   } finally {
     clearTimeout(tid)
   }

--- a/ipfs-config.sh
+++ b/ipfs-config.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# kubo config docs: https://github.com/ipfs/kubo/blob/master/docs/config.md
+
+# dont add provider records to the dht... e-ipfs will do that.
+ipfs config --json Experimental.StrategicProviding true
+
+# as per gateways
+ipfs config --json Swarm.DisableBandwidthMetrics true
+
+# we manually connect to nodes that send `origins` so we dont need loads of connections here.
+ipfs config --json Swarm.ConnMgr.HighWater 100
+ipfs config --json Swarm.ConnMgr.LowWater 50
+
+# no MDNS plz
+ipfs config --json Discovery.MDNS.Enabled false
+
+# plz fail early if bits get flipped in blockstore
+ipfs config --json Datastore.HashOnRead true
+
+# set `Datastore.Spec.mounts.[0].child.sync false` to avoid needless extra sync calls for much perf boost.
+# otherwise the rest is defaults, but we can't use ipfs config to set items in an array!
+ipfs config --json Datastore.Spec.mounts '[
+  {
+    "child": {
+      "path": "blocks",
+      "shardFunc": "/repo/flatfs/shard/v1/next-to-last/2",
+      "sync": false,
+      "type": "flatfs"
+    },
+    "mountpoint": "/blocks",
+    "prefix": "flatfs.datastore",
+    "type": "measure"
+  },
+  {
+    "child": {
+      "compression": "none",
+      "path": "datastore",
+      "type": "levelds"
+    },
+    "mountpoint": "/",
+    "prefix": "leveldb.datastore",
+    "type": "measure"
+  }
+]'
+
+echo "kubo config updated!"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3094,9 +3094,9 @@
       }
     },
     "node_modules/go-ipfs": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/go-ipfs/-/go-ipfs-0.18.0.tgz",
-      "integrity": "sha512-CFKHjN7nco2EUxQSdM7AQ3VzLASxwmP4RBDx8TeLqEgn5K2fjIYN7IHkna104UNpsVNhtzVBy0OObBczJWrLUA==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/go-ipfs/-/go-ipfs-0.18.1.tgz",
+      "integrity": "sha512-hXfjQRqet/H8mTSQVKiuTSMrvjv8cAGQMHbr12DHAHGsSMS9IuGCOntkVEhnNOnmP/WXcrxRVxLu6xz/mPLlZg==",
       "hasInstallScript": true,
       "dependencies": {
         "cachedir": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "start": "run-p start:*",
-    "start:ipfs": "ipfs daemon --init --init-profile=server",
+    "start": "npm-run-all -s ipfs-config -p start:*",
+    "start:ipfs": "ipfs daemon",
     "start:backup": "node bin.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "ipfs-config":"ipfs init --profile=server --empty-repo && ./ipfs-config.sh"
   },
   "author": "Alan Shaw",
   "license": "(Apache-2.0 OR MIT)",


### PR DESCRIPTION
- Add ipfs config overrides to match what we do in pickup
- stop trying to set an err.code to fix https://github.com/web3-storage/backup/issues/5
- add --silent to supress npm noise from `npm start` for fewer logs.
- Update kubo to 0.18.1 https://github.com/ipfs/kubo/releases/tag/v0.18.1


License: MIT