### PR TITLE
feat: test, build, and publish docker image from ci

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -1,0 +1,15 @@
+name: Test
+description: 'Setup and test'
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-node@v3
+      with:
+        registry-url: 'https://registry.npmjs.org'
+        node-version: 18
+        cache: 'npm'
+    - run: npm ci
+      shell: bash
+    - run: npm test
+      shell: bash

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,4 +1,4 @@
-name: Publish image to ECR
+name: ECR
 
 on:
   push:
@@ -10,13 +10,13 @@ on:
 
 jobs:
   deploy:
-    name: Deploy
+    name: Publish image
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - run: echo "SHORT_SHA=`echo ${{ github.sha }} | cut -c1-8`" >> $GITHUB_ENV
     - run: echo "DATE=$(date -u +"%Y-%m-%d")" >> $GITHUB_ENV
-    - run: echo "IMAGE_TAG=$DATE-$SHORT_SHA"
+    - run: echo "IMAGE_TAG=$DATE-$SHORT_SHA" >> $GITHUB_ENV
     - name: Build, tag, and push image to Amazon ECR
       run: |
         docker build -t $IMAGE_TAG .

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -3,9 +3,6 @@ name: ECR
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 env:

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -8,15 +8,37 @@ on:
       - main
   workflow_dispatch:
 
+env:
+  AWS_REGION: us-west-2
+  ECR_REPOSITORY: prod-backup-ipfs-cluster
+
 jobs:
   deploy:
     name: Publish image
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - run: echo "SHORT_SHA=`echo ${{ github.sha }} | cut -c1-8`" >> $GITHUB_ENV
-    - run: echo "DATE=$(date -u +"%Y-%m-%d")" >> $GITHUB_ENV
-    - run: echo "IMAGE_TAG=$DATE-$SHORT_SHA" >> $GITHUB_ENV
-    - name: Build, tag, and push image to Amazon ECR
-      run: |
-        docker build -t $IMAGE_TAG .
+      - uses: actions/checkout@v3
+      - run: echo "SHORT_SHA=`echo ${{ github.sha }} | cut -c1-8`" >> $GITHUB_ENV
+      - run: echo "DATE=$(date -u +"%Y-%m-%d")" >> $GITHUB_ENV
+      - run: echo "IMAGE_TAG=$DATE-$SHORT_SHA" >> $GITHUB_ENV
+
+      - run: docker build -t $IMAGE_TAG .
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838
+        with:
+          aws-access-key-id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+    
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@261a7de32bda11ba01f4d75c4ed6caf3739e54be
+
+      - name: Publish Docker image to ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          docker tag $IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          echo "Published `$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: echo "SHORT_SHA=`echo ${{ github.sha }} | cut -c1-8`" >> $GITHUB_ENV
-    - run: echo "DATE=${date -u +"%Y-%m-%d"}" >> $GITHUB_ENV
+    - run: echo "DATE=$(date -u +"%Y-%m-%d")" >> $GITHUB_ENV
     - run: echo "IMAGE_TAG=$DATE-$SHORT_SHA"
     - name: Build, tag, and push image to Amazon ECR
       run: |

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,19 @@
+name: Publish image to ECR
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: echo "SHORT_SHA=`echo ${{ github.sha }} | cut -c1-8`" >> $GITHUB_ENV
+    - run: echo "DATE=${date -u +"%Y-%m-%d"}" >> $GITHUB_ENV
+    - run: echo "IMAGE_TAG=$DATE-$SHORT_SHA"
+    - name: Build, tag, and push image to Amazon ECR
+      run: |
+        docker build -t $IMAGE_TAG .

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -3,6 +3,9 @@ name: Publish image to ECR
 on:
   push:
     branches: [ main ]
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,13 @@
+name: Test
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.14.2-alpine
+FROM node:18.14.2-slim
 
 WORKDIR /usr/src/app
 COPY package*.json *.js ./

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start:ipfs": "ipfs daemon",
     "start:backup": "node bin.js",
     "lint": "standard",
-    "test": "DEBUG=testcontainers:containers ava test.js",
+    "test": "standard && DEBUG=testcontainers:containers ava test.js",
     "ipfs-config": "ipfs init --profile=server --empty-repo && ./ipfs-config.sh",
     "make-peers": "node --no-warnings peers.js > peers.json"
   },

--- a/test.js
+++ b/test.js
@@ -21,7 +21,7 @@ test('backup a dag', async t => {
   const bucketName = 'backup-test'
   const region = 'us-east-1'
 
-  const mb = await createBucket(bucketName, minio, accessKeyId, secretAccessKey)
+  const mb = await createBucket(bucketName, minio, accessKeyId, secretAccessKey, region)
   t.is(mb.$metadata.httpStatusCode, 200)
 
   const img = await GenericContainer.fromDockerfile('.').build()

--- a/test.js
+++ b/test.js
@@ -19,6 +19,7 @@ test('backup a dag', async t => {
   const accessKeyId = 'minioadmin'
   const secretAccessKey = 'minioadmin'
   const bucketName = 'backup-test'
+  const region = 'us-east-1'
 
   const mb = await createBucket(bucketName, minio, accessKeyId, secretAccessKey)
   t.is(mb.$metadata.httpStatusCode, 200)
@@ -33,7 +34,7 @@ test('backup a dag', async t => {
     DEBUG: 'backup:*',
     DATA_URL: 'https://bafybeiha7xoedojqjz6ghxdtbf7yx2eklwo7db36772u3odrjusqck3ljm.ipfs.w3s.link/ipfs/bafybeiha7xoedojqjz6ghxdtbf7yx2eklwo7db36772u3odrjusqck3ljm/nft-0.json',
     S3_ENDPOINT: s3Endpoint,
-    S3_REGION: 'us-east-1',
+    S3_REGION: region,
     S3_BUCKET_NAME: bucketName,
     S3_ACCESS_KEY_ID: accessKeyId,
     S3_SECRET_ACCESS_KEY: secretAccessKey
@@ -52,9 +53,10 @@ test('backup a dag', async t => {
   }
 })
 
-async function createBucket (bucketName, minio, accessKeyId, secretAccessKey) {
+async function createBucket (bucketName, minio, accessKeyId, secretAccessKey, region) {
   const endpoint = `http://${minio.getHost()}:${minio.getMappedPort(9000)}` // host to container
   const s3 = new S3Client({
+    region,
     endpoint,
     forcePathStyle: true,
     credentials: {


### PR DESCRIPTION
- run tests in CI
- push a docker image to our ECR repo from ci on merge to main

For this to work a new IAM user has been created with permissions to push to the registry and secrets have been configured to allow this repo to use the credentials.

see example run where image is published: https://github.com/web3-storage/backup/actions/runs/4315840231/jobs/7530839132

related docs: https://docs.github.com/en/actions/deployment/deploying-to-your-cloud-provider/deploying-to-amazon-elastic-container-service

License: MIT