### PR TITLE
fix: dont stall waiting for a single large item in a batch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,5 @@ RUN npm ci --omit=dev
 COPY *.js *.json *.sh ./
 CMD [ "npm", "start", "--silent"]
 
+EXPOSE 9999
 HEALTHCHECK --interval=60s --timeout=1s --start-period=5s --retries=3 CMD [ "curl" "https://127.0.0.1:9999" "--fail" ]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ S3_ACCESS_KEY_ID=<value> # optional
 S3_SECRET_ACCESS_KEY=<value> # optional
 S3_ENDPOINT=<url> # optional, used to test against minio
 CONCURRENCY=<number> # optional
-BATCH_SIZE=<number> # optional
 ```
 
 Start the backup:

--- a/bin.js
+++ b/bin.js
@@ -13,7 +13,6 @@ startBackup({
   s3SecretAccessKey: process.env.S3_SECRET_ACCESS_KEY,
   s3Endpoint: process.env.S3_ENDPOINT,
   concurrency: process.env.CONCURRENCY ? parseInt(process.env.CONCURRENCY) : undefined,
-  batchSize: process.env.BATCH_SIZE ? parseInt(process.env.BATCH_SIZE) : undefined,
   healthcheckPort: process.env.HEALTHCHECK_PORT ? parseInt(process.env.HEALTHCHECK_PORT) : undefined
 })
 

--- a/index.js
+++ b/index.js
@@ -28,9 +28,9 @@ const REPORT_INTERVAL = 1000 * 60 // log download progress every minute
  * @param {string} [config.s3SecretAccessKey]
  * @param {string} [config.s3Endpoint]
  * @param {number} [config.concurrency]
- * @param {number} [config.batchSize]
+ * @param {number} [config.healthcheckPort]
  */
-export async function startBackup ({ dataURL, s3Region, s3BucketName, s3AccessKeyId, s3SecretAccessKey, s3Endpoint, concurrency, batchSize, healthcheckPort = 9999 }) {
+export async function startBackup ({ dataURL, s3Region, s3BucketName, s3AccessKeyId, s3SecretAccessKey, s3Endpoint, concurrency, healthcheckPort = 9999 }) {
   const sourceDataFile = dataURL.substring(dataURL.lastIndexOf('/') + 1)
   const gracePeriodMs = REPORT_INTERVAL * 2
   const health = createHealthCheckServer({ sourceDataFile, gracePeriodMs })

--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ import retry from 'p-retry'
 import { transform } from 'streaming-iterables'
 import { parse } from 'it-ndjson'
 import { pipe } from 'it-pipe'
-import batch from 'it-batch'
 import formatNumber from 'format-number'
 import { CID } from 'multiformats'
 import { IpfsClient } from './ipfs-client.js'
@@ -14,7 +13,6 @@ import { createHealthCheckServer } from './health.js'
 
 const fmt = formatNumber()
 
-const BATCH_SIZE = 100
 const CONCURRENCY = 10
 const BLOCK_TIMEOUT = 1000 * 30 // timeout if we don't receive a block after 30s
 const REPORT_INTERVAL = 1000 * 60 // log download progress every minute
@@ -67,52 +65,39 @@ export async function startBackup ({ dataURL, s3Region, s3BucketName, s3AccessKe
   await pipe(
     fetchCID(dataURL, log),
     filterAlreadyStored(s3, s3BucketName, log),
-    source => batch(source, batchSize ?? BATCH_SIZE),
-    async function (source) {
-      for await (const batch of source) {
-        await pipe(
-          batch,
-          transform(concurrency ?? CONCURRENCY, async (item) => {
-            log(`processing ${item.cid}`)
-            try {
-              const size = await retry(async () => {
-                let size = 0
-                const source = (async function * () {
-                  for await (const chunk of exportCar(ipfs, item, log)) {
-                    size += chunk.length
-                    yield chunk
-                  }
-                })()
-                await s3Upload(s3, s3BucketName, item, source, log)
-                return size
-              }, { onFailedAttempt: info => log(info) })
-              totalSuccessful++
-              return { sourceDataFile, cid: item.cid, status: 'ok', size }
-            } catch (err) {
-              log(`failed to backup ${item.cid}`, err)
-              return { sourceDataFile, cid: item.cid, status: 'error', error: err.message }
-            } finally {
-              totalProcessed++
-              log(`processed ${totalSuccessful} of ${totalProcessed} CIDs successfully`)
+    transform(concurrency ?? CONCURRENCY, async (item) => {
+      log(`processing ${item.cid}`)
+      try {
+        const size = await retry(async () => {
+          let size = 0
+          const source = (async function * () {
+            for await (const chunk of exportCar(ipfs, item, log)) {
+              size += chunk.length
+              yield chunk
             }
-          }),
-          async function (source) {
-            for await (const item of source) {
-              console.log(JSON.stringify(item))
-            }
-          }
-        )
-
-        log(`garbage collecting batch of ${batch.length} root CIDs`)
-        let count = 0
+          })()
+          await s3Upload(s3, s3BucketName, item, source, log)
+          return size
+        }, { onFailedAttempt: info => log(info) })
+        totalSuccessful++
+        return { sourceDataFile, cid: item.cid, status: 'ok', size }
+      } catch (err) {
+        log(`failed to backup ${item.cid}`, err)
+        return { sourceDataFile, cid: item.cid, status: 'error', error: err.message }
+      } finally {
+        totalProcessed++
+        log(`processed ${totalSuccessful} of ${totalProcessed} CIDs successfully`)
         for await (const res of ipfs.repoGc()) {
           if (res.err) {
             log(`failed to GC ${res.cid}:`, res.err)
             continue
           }
-          count++
         }
-        log(`garbage collected ${count} CIDs`)
+      }
+    }),
+    async function (source) {
+      for await (const item of source) {
+        console.log(JSON.stringify(item))
       }
     }
   )

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -30,7 +30,7 @@ test('backup a dag', async t => {
   img.withNetwork(network)
   img.withEnvironment({
     BATCH_SIZE: 1,
-    CONCURRENCY: 50,
+    CONCURRENCY: 1,
     DEBUG: 'backup:*',
     DATA_URL: 'https://bafybeiha7xoedojqjz6ghxdtbf7yx2eklwo7db36772u3odrjusqck3ljm.ipfs.w3s.link/ipfs/bafybeiha7xoedojqjz6ghxdtbf7yx2eklwo7db36772u3odrjusqck3ljm/nft-0.json',
     S3_ENDPOINT: s3Endpoint,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -30,7 +30,7 @@ test('backup a dag', async t => {
   img.withNetwork(network)
   img.withEnvironment({
     BATCH_SIZE: 1,
-    CONCURRENCY: 1,
+    CONCURRENCY: 50,
     DEBUG: 'backup:*',
     DATA_URL: 'https://bafybeiha7xoedojqjz6ghxdtbf7yx2eklwo7db36772u3odrjusqck3ljm.ipfs.w3s.link/ipfs/bafybeiha7xoedojqjz6ghxdtbf7yx2eklwo7db36772u3odrjusqck3ljm/nft-0.json',
     S3_ENDPOINT: s3Endpoint,


### PR DESCRIPTION
no batching! just gc all the time. Once a block is written to the output stream, it's fair game for GC anyway, and if we GC a thing we hadn't written yet, kubo can just go fetch it again.

I'm seeing containers idling while a single large dag is fetched.

License: MIT