### PR TITLE
fix: retry input fetch and exit process on error

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -5,17 +5,22 @@ import { startBackup } from './index.js'
 
 dotenv.config()
 
-startBackup({
-  dataURL: mustGetEnv('DATA_URL'),
-  s3Region: mustGetEnv('S3_REGION'),
-  s3BucketName: mustGetEnv('S3_BUCKET_NAME'),
-  s3AccessKeyId: process.env.S3_ACCESS_KEY_ID,
-  s3SecretAccessKey: process.env.S3_SECRET_ACCESS_KEY,
-  s3Endpoint: process.env.S3_ENDPOINT,
-  concurrency: process.env.CONCURRENCY ? parseInt(process.env.CONCURRENCY) : undefined,
-  batchSize: process.env.BATCH_SIZE ? parseInt(process.env.BATCH_SIZE) : undefined,
-  healthcheckPort: process.env.HEALTHCHECK_PORT ? parseInt(process.env.HEALTHCHECK_PORT) : undefined
-})
+try {
+  await startBackup({
+    dataURL: mustGetEnv('DATA_URL'),
+    s3Region: mustGetEnv('S3_REGION'),
+    s3BucketName: mustGetEnv('S3_BUCKET_NAME'),
+    s3AccessKeyId: process.env.S3_ACCESS_KEY_ID,
+    s3SecretAccessKey: process.env.S3_SECRET_ACCESS_KEY,
+    s3Endpoint: process.env.S3_ENDPOINT,
+    concurrency: process.env.CONCURRENCY ? parseInt(process.env.CONCURRENCY) : undefined,
+    batchSize: process.env.BATCH_SIZE ? parseInt(process.env.BATCH_SIZE) : undefined,
+    healthcheckPort: process.env.HEALTHCHECK_PORT ? parseInt(process.env.HEALTHCHECK_PORT) : undefined
+  })
+} catch (err) {
+  console.error('exiting! startBackup threw error', err)
+  process.exit(1)
+}
 
 /**
  * @param {string} name

--- a/index.js
+++ b/index.js
@@ -125,7 +125,7 @@ export async function startBackup ({ dataURL, s3Region, s3BucketName, s3AccessKe
  * @returns {AsyncIterable<InputData>}
  */
 async function * fetchCID (url, log) {
-  const res = await fetch(url)
+  const res = await retry(() => fetch(url), { onFailedAttempt: err => log(`error trying to fetchCID ${err.message} attempt: ${err.attemptNumber}`) })
   if (!res.ok || !res.body) {
     const errMessage = `failed to fetch CIDs: ${url}`
     log(errMessage)


### PR DESCRIPTION
seeing lots of containers fail to restart with an uncaught fetch error, but the container is not stopping, so the service is not restarting them. see: https://github.com/web3-storage/backup/issues/11

License: MIT