### PR TITLE
fix: fetch entire input file before starting processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 out
 dedupe
 pinned
+data

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,5 +1,6 @@
 import { GenericContainer, Wait, Network } from 'testcontainers'
 import { S3Client, CreateBucketCommand } from '@aws-sdk/client-s3'
+import { fetchData } from '../index.js'
 import test from 'ava'
 
 test('backup a dag', async t => {
@@ -32,7 +33,7 @@ test('backup a dag', async t => {
     BATCH_SIZE: 1,
     CONCURRENCY: 1,
     DEBUG: 'backup:*',
-    DATA_URL: 'https://bafybeiha7xoedojqjz6ghxdtbf7yx2eklwo7db36772u3odrjusqck3ljm.ipfs.w3s.link/ipfs/bafybeiha7xoedojqjz6ghxdtbf7yx2eklwo7db36772u3odrjusqck3ljm/nft-0.json',
+    DATA_URL: 'https://bafybeiha7xoedojqjz6ghxdtbf7yx2eklwo7db36772u3odrjusqck3ljm.ipfs.w3s.link/nft-0.json',
     S3_ENDPOINT: s3Endpoint,
     S3_REGION: region,
     S3_BUCKET_NAME: bucketName,
@@ -66,3 +67,12 @@ async function createBucket (bucketName, minio, accessKeyId, secretAccessKey, re
   })
   return s3.send(new CreateBucketCommand({ Bucket: bucketName }))
 }
+
+test('fetchData', async t => {
+  const data = await fetchData('https://bafybeiavn43yjnai7dhtyrxl5n3euhcsyzxz34gpg44nvy7x2ugs5j7fg4.ipfs.w3s.link/x', console.log)
+  const chunks = []
+  for await (const chunk of data) {
+    chunks.push(chunk)
+  }
+  t.is(chunks.join(''), 'test\n')
+})


### PR DESCRIPTION
we're seeing backup processes fail where fetching the input url fail mid stream.

this PR tweaks it to fetch the entire data file to disk at the start and then stream them from the local disk.

see: https://github.com/web3-storage/backup/issues/11

of note `p-retry` won't retry for network errors! Hence the surprising manual retry loop.
> It does not retry on most TypeError's, with the exception of network errors. This is done on a best case basis
> – https://github.com/sindresorhus/p-retry#api

License: MIT