### PR TITLE
fix: reduce DAG export retries

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,10 @@ export async function startBackup ({ dataURL, s3Region, s3BucketName, s3AccessKe
           })()
           await s3Upload(s3, s3BucketName, item, source, log)
           return size
-        }, { onFailedAttempt: info => log(info) })
+        }, {
+          onFailedAttempt: info => log(info),
+          retries: 2
+        })
         totalSuccessful++
         return { sourceDataFile, cid: item.cid, status: 'ok', size }
       } catch (err) {


### PR DESCRIPTION
Retrying 10 times with exponential backoff makes for long periods without any action. Reduce the retries to allow us to process more faster.