### PR TITLE
chore: log retry attempts as single line

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ export async function startBackup ({ dataURL, s3Region, s3BucketName, s3AccessKe
           await s3Upload(s3, s3BucketName, item, source, log)
           return size
         }, {
-          onFailedAttempt: info => log(info),
+          onFailedAttempt: info => log('failed attempt exportCar: %o', info),
           retries: 2
         })
         totalSuccessful++


### PR DESCRIPTION
make it easier to dig around in the logs. multi-line logs are a pain e.g

<img width="1582" alt="Screenshot 2023-05-01 at 13 56 36" src="https://user-images.githubusercontent.com/58871/235457456-417a2fbf-8665-4111-8cac-28a8f57c2f5f.png">
