### PR TITLE
fix: ignore CONCURRENCY for s3 head requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,7 +159,7 @@ function filterAlreadyStored (s3, bucket, log) {
   return async function * (source) {
     yield * pipe(
       source,
-      transform(CONCURRENCY, async item => {
+      transform(100, async item => {
         const cmd = new HeadObjectCommand({ Bucket: bucket, Key: bucketKey(item.cid) })
         try {
           await s3.send(cmd)


### PR DESCRIPTION
we lowered the concurrency to 1 to try and stop the process locking up, but we don't want to make the s3 HEAD checks slower. LETS MAKE THEM FASTER!

License: MIT